### PR TITLE
Search for bugs

### DIFF
--- a/game/src/combat.rs
+++ b/game/src/combat.rs
@@ -290,7 +290,10 @@ fn apply_damage(
     time: Res<Time>,
 ) {
     for (hitbox, attack_hitbox) in hitbox_query.iter() {
-        let attacker_stats = attacker_query.get(attack_hitbox.owner).unwrap();
+        // Safely get attacker stats, skip if attacker entity doesn't exist
+        let Ok(attacker_stats) = attacker_query.get(attack_hitbox.owner) else {
+            continue;
+        };
 
         for &hit_entity in hitbox.hit_entities.iter() {
             if let Ok((entity, mut health, transform, defender_stats, maybe_enemy)) = target_query.get_mut(hit_entity) {

--- a/game/src/enemy.rs
+++ b/game/src/enemy.rs
@@ -34,11 +34,9 @@ fn update_enemy_ai(
     player_query: Query<(Entity, &Transform), With<LocalPlayer>>,
     time: Res<Time>,
 ) {
-    let player = player_query.get_single();
-    if player.is_err() {
+    let Ok((player_entity, player_transform)) = player_query.get_single() else {
         return; // No player to target
-    }
-    let (player_entity, player_transform) = player.unwrap();
+    };
     let player_pos = player_transform.translation.truncate();
 
     for (mut ai, enemy, transform, health, entity) in enemy_query.iter_mut() {
@@ -187,7 +185,7 @@ fn enemy_movement(
     if player_transform.is_err() {
         return;
     }
-    let player_pos = player_transform.unwrap().translation.truncate();
+    let player_pos = player_transform.translation.truncate();
 
     for (mut transform, mut velocity, enemy, ai) in enemy_query.iter_mut() {
         let enemy_pos = transform.translation.truncate();
@@ -266,7 +264,7 @@ fn enemy_attack_system(
     if player_transform.is_err() {
         return;
     }
-    let player_pos = player_transform.unwrap().translation.truncate();
+    let player_pos = player_transform.translation.truncate();
 
     for (entity, transform, enemy, ai, stats) in enemy_query.iter() {
         if ai.state != AIState::Attacking {

--- a/game/src/room.rs
+++ b/game/src/room.rs
@@ -571,7 +571,7 @@ fn handle_door_interaction(
     if player_transform.is_err() {
         return;
     }
-    let player_pos = player_transform.unwrap().translation.truncate();
+    let player_pos = player_transform.translation.truncate();
     
     for (door, door_transform) in door_query.iter() {
         let door_pos = door_transform.translation.truncate();


### PR DESCRIPTION
Replace `unwrap()` calls in Rust game code with safer error handling to prevent panics.

---
<a href="https://cursor.com/background-agent?bcId=bc-edc39769-f6de-4980-b0be-a17b035902d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edc39769-f6de-4980-b0be-a17b035902d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

