### PR TITLE
Monitor demo performance and variable access

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -7,6 +7,12 @@ let latencyCounter = 12;
 let memoryCounter = 48;
 let entitiesCounter = 127;
 
+// Expose performance counters to window for monitoring
+window.fpsCounter = fpsCounter;
+window.latencyCounter = latencyCounter;
+window.memoryCounter = memoryCounter;
+window.entitiesCounter = entitiesCounter;
+
 // WebRTC demo state
 let roomCode = null;
 let peers = [];
@@ -57,6 +63,7 @@ function startPerformanceMonitoring() {
             
             if (currentTime >= lastTime + 1000) {
                 fpsCounter = Math.round((frameCount * 1000) / (currentTime - lastTime));
+                window.fpsCounter = fpsCounter; // Update window property
                 const fpsElement = document.getElementById('fps-counter');
                 if (fpsElement) {
                     fpsElement.textContent = fpsCounter;
@@ -100,6 +107,11 @@ function updateMetrics() {
             latencyCounter = Math.floor(Math.random() * 20) + 10;
             memoryCounter = Math.floor(Math.random() * 30) + 40;
             entitiesCounter = Math.floor(Math.random() * 50) + 100;
+            
+            // Update window properties
+            window.latencyCounter = latencyCounter;
+            window.memoryCounter = memoryCounter;
+            window.entitiesCounter = entitiesCounter;
             
             const latencyElement = document.getElementById('latency-counter');
             const memoryElement = document.getElementById('memory-counter');

--- a/test-variables.html
+++ b/test-variables.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Demo Variables</title>
+    <style>
+        body {
+            font-family: monospace;
+            padding: 20px;
+            background: #1a1a1a;
+            color: #0f0;
+        }
+        button {
+            background: #0f0;
+            color: #000;
+            border: none;
+            padding: 10px 20px;
+            margin: 5px;
+            cursor: pointer;
+            font-weight: bold;
+        }
+        #result {
+            background: #000;
+            padding: 10px;
+            border: 1px solid #0f0;
+            margin-top: 20px;
+            min-height: 200px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Test Demo Variables Access</h1>
+    <button onclick="testDirectAccess()">Test Direct Access</button>
+    <button onclick="testIframeAccess()">Test IFrame Access</button>
+    <div id="result"></div>
+    <iframe id="testFrame" src="" width="100%" height="400" style="border: 1px solid #0f0; margin-top: 20px; display: none;"></iframe>
+
+    <script>
+        const result = document.getElementById('result');
+        
+        function log(msg, color = '#0f0') {
+            const line = document.createElement('div');
+            line.style.color = color;
+            line.textContent = msg;
+            result.appendChild(line);
+        }
+        
+        function testDirectAccess() {
+            result.innerHTML = '';
+            log('Testing direct access to window variables...');
+            
+            // Load demo.js directly
+            const script = document.createElement('script');
+            script.src = 'demo.js';
+            script.onload = () => {
+                log('demo.js loaded');
+                
+                // Check for variables
+                if (window.fpsCounter !== undefined) {
+                    log(`✓ fpsCounter: ${window.fpsCounter}`, '#0f0');
+                } else {
+                    log('✗ fpsCounter not found', '#f00');
+                }
+                
+                if (window.latencyCounter !== undefined) {
+                    log(`✓ latencyCounter: ${window.latencyCounter}`, '#0f0');
+                } else {
+                    log('✗ latencyCounter not found', '#f00');
+                }
+                
+                if (window.memoryCounter !== undefined) {
+                    log(`✓ memoryCounter: ${window.memoryCounter}`, '#0f0');
+                } else {
+                    log('✗ memoryCounter not found', '#f00');
+                }
+                
+                if (window.entitiesCounter !== undefined) {
+                    log(`✓ entitiesCounter: ${window.entitiesCounter}`, '#0f0');
+                } else {
+                    log('✗ entitiesCounter not found', '#f00');
+                }
+            };
+            document.head.appendChild(script);
+        }
+        
+        function testIframeAccess() {
+            result.innerHTML = '';
+            log('Loading demo.html in iframe...');
+            
+            const iframe = document.getElementById('testFrame');
+            iframe.style.display = 'block';
+            iframe.src = 'demo.html';
+            
+            iframe.onload = () => {
+                log('IFrame loaded, waiting 2 seconds for demo to initialize...');
+                
+                setTimeout(() => {
+                    try {
+                        const iframeWindow = iframe.contentWindow;
+                        
+                        log('Checking iframe window variables:');
+                        
+                        if (iframeWindow.fpsCounter !== undefined) {
+                            log(`✓ fpsCounter: ${iframeWindow.fpsCounter}`, '#0f0');
+                        } else {
+                            log('✗ fpsCounter not accessible', '#f00');
+                        }
+                        
+                        if (iframeWindow.latencyCounter !== undefined) {
+                            log(`✓ latencyCounter: ${iframeWindow.latencyCounter}`, '#0f0');
+                        } else {
+                            log('✗ latencyCounter not accessible', '#f00');
+                        }
+                        
+                        if (iframeWindow.memoryCounter !== undefined) {
+                            log(`✓ memoryCounter: ${iframeWindow.memoryCounter}`, '#0f0');
+                        } else {
+                            log('✗ memoryCounter not accessible', '#f00');
+                        }
+                        
+                        if (iframeWindow.entitiesCounter !== undefined) {
+                            log(`✓ entitiesCounter: ${iframeWindow.entitiesCounter}`, '#0f0');
+                        } else {
+                            log('✗ entitiesCounter not accessible', '#f00');
+                        }
+                        
+                        // Try monitoring for 5 seconds
+                        log('', '#0ff');
+                        log('Starting 5-second monitoring...', '#0ff');
+                        let count = 0;
+                        const interval = setInterval(() => {
+                            count++;
+                            if (count > 5) {
+                                clearInterval(interval);
+                                log('Monitoring complete!', '#0ff');
+                                return;
+                            }
+                            
+                            try {
+                                log(`[${count}s] FPS: ${iframeWindow.fpsCounter}, Latency: ${iframeWindow.latencyCounter}ms, Memory: ${iframeWindow.memoryCounter}MB, Entities: ${iframeWindow.entitiesCounter}`, '#0ff');
+                            } catch (e) {
+                                log(`[${count}s] Error: ${e.message}`, '#f00');
+                            }
+                        }, 1000);
+                        
+                    } catch (e) {
+                        log(`Error accessing iframe: ${e.message}`, '#f00');
+                    }
+                }, 2000);
+            };
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Expose demo performance counter variables to the window object to enable external monitoring.

The demo monitor, running in an iframe, was unable to access `fpsCounter`, `latencyCounter`, `memoryCounter`, and `entitiesCounter` because they were not attached to the global `window` object. This change makes them accessible, resolving the "Cannot access demo variables" error. A new test file `test-variables.html` is included to verify the fix.

---
<a href="https://cursor.com/background-agent?bcId=bc-39e034df-a678-43d4-bd45-50fba660b410">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39e034df-a678-43d4-bd45-50fba660b410">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

